### PR TITLE
Add ON_ERROR_STOP to psql in test script

### DIFF
--- a/tests/scripts/run-all-tests.sh
+++ b/tests/scripts/run-all-tests.sh
@@ -44,9 +44,9 @@ run_sql_test() {
     echo -e "${BLUE}Running $test_name...${NC}"
     
     if [ "$VERBOSE" = true ]; then
-        psql "$TEST_DB_URL" -f "$test_file"
+        psql "$TEST_DB_URL" -v ON_ERROR_STOP=1 -f "$test_file"
     else
-        psql "$TEST_DB_URL" -f "$test_file" > /dev/null 2>&1
+        psql "$TEST_DB_URL" -v ON_ERROR_STOP=1 -f "$test_file" > /dev/null 2>&1
     fi
     
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Summary
- ensure `psql` stops on SQL errors when running test suites

## Testing
- `npm test` *(fails: psql not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e90ca8e58832788dcb9ce14f748a2