### PR TITLE
Fix privacy_settings camelCase usage

### DIFF
--- a/src/components/FoundationTest.tsx
+++ b/src/components/FoundationTest.tsx
@@ -212,7 +212,7 @@ const FoundationTest = () => {
                   email,
                   display_name: displayName,
                   is_child: false,
-                  privacy_settings: { data_sharing: false, analytics: false },
+                  privacy_settings: { dataSharing: false, analytics: false, marketing: false },
                   preferred_language: 'ru'
                 })
                 .select()
@@ -274,7 +274,7 @@ const FoundationTest = () => {
           email,
           display_name: displayName,
           is_child: false,
-          privacy_settings: { data_sharing: false, analytics: false },
+          privacy_settings: { dataSharing: false, analytics: false, marketing: false },
           preferred_language: 'ru'
         })
         .select()

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -271,7 +271,7 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => 
           email,
           display_name: displayName,
           is_child: false,
-          privacy_settings: { data_sharing: false, analytics: false },
+          privacy_settings: { dataSharing: false, analytics: false, marketing: false },
           preferred_language: 'en'
         })
         .select()
@@ -326,7 +326,7 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => 
             email: data.user.email,
             display_name: data.user.email?.split('@')[0] || 'User',
             is_child: false,
-            privacy_settings: { data_sharing: false, analytics: false },
+            privacy_settings: { dataSharing: false, analytics: false, marketing: false },
             preferred_language: 'en'
           })
           .select()

--- a/tests/scripts/setup-test-environment.sh
+++ b/tests/scripts/setup-test-environment.sh
@@ -150,7 +150,7 @@ VALUES (
     'Test Parent',
     false,
     'testparent@example.com',
-    '{"data_sharing": false, "analytics": false}'::jsonb
+    '{"dataSharing": false, "analytics": false, "marketing": false}'::jsonb
 );
 
 -- Create test child
@@ -170,7 +170,7 @@ BEGIN
         '2015-01-01',
         true,
         now(),
-        '{"data_sharing": false, "analytics": false}'::jsonb
+        '{"dataSharing": false, "analytics": false, "marketing": false}'::jsonb
     );
     
     -- Link parent and child


### PR DESCRIPTION
## Summary
- ensure profile creation uses camelCase keys for `privacy_settings`
- update FoundationTest component and test setup script to match interface

## Testing
- `npm test` *(fails: psql missing)*
- `npm run lint` *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_686e9428fde48327b4d3d5fd8d26a77a